### PR TITLE
Update installing instructions for Windows(ruby with DevKit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ source ~/.zshrc
 <br /><br />
 ### Windows
 
-- Install ruby 2.7 without DevKit: https://rubyinstaller.org/downloads/
+- Install ruby 2.7 with DevKit: https://rubyinstaller.org/downloads/
 - git clone this repository or download as a zip file
 - extract into C:\norminette
 - Go inside this folder with cmd.exe


### PR DESCRIPTION
I tried to use norminette with ruby 2.7 without DevKit, but norminette was not working because of json install error.
ruby 2.7 with DevKit(x64) is working!